### PR TITLE
Change README to note moved from quarkus to java

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ github.com/java-operator-sdk/kubebuilder-plugin => /Users/sushah/go/src/github.c
 - Add the java-operator-sdk import
 
 ```
-javav1 "github.com/java-operator-sdk/kubebuilder-plugin/pkg/quarkus/v1"
+javav1 "github.com/java-operator-sdk/kubebuilder-plugin/pkg/java/v1"
 ```
 
 - Introduce the java bundle in `GetPluginsCLIAndRoot()` method. 


### PR DESCRIPTION
Seems to now be `kubebuilder-plugin/pkg/java/v1` so updating README to match